### PR TITLE
Allow export of tags to be disabled

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 # Changelog for aws-metadata-export
 
+## 0.2.0
+
+* add the ability to not export tags, which allows collection without using the AWS API (and thus requires no keys/secrets/IAM bits)
+
 ## 0.1.0
 
 * initial version

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ The following instance data files are written:
 * az
 
 Tags are written to the a 'tags' directory.  Each file is the name of a
-tag and the contents of that file is the value of the tag.
+tag and the contents of that file is the value of the tag.  To disable
+tag export, pass `--no-tags` to the command line.
 
 ## INSTALLATION
 
@@ -45,6 +46,11 @@ done in your userdata if the instance has a path to rubygems.org.
 Tags are not exported through EC2 instance data, so the EC2 API must be
 used to fetch them.  As such, the IAM permission `ec2:DescribeInstances`
 must be available via an IAM instance profile and role.
+
+If you wish to use the gem on a node without an IAM instance profile,
+you can pass `export_tags: false` to the export method or `--no-tags` to
+the CLI, in which case only the metdata that can be fetched from the
+metadata endpoint will be exported.
 
 ## ENVIRONMENT VARIABLES
 

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ begin
     license 'MIT'
     extra_deps << ['aws-sdk', '~> 2.0']
     extra_deps << ['ec2-metadata', '~> 0.2']
-    extra_deps << ['slop', '~> 4.2']
+    extra_deps << ['slop', '~> 3.6']
     extra_dev_deps << ['hoe', '~> 3.13']
     extra_dev_deps << ['hoe-gemspec', '~> 1.0']
     extra_dev_deps << ['rake', '~> 10.3']

--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,7 @@ begin
     license 'MIT'
     extra_deps << ['aws-sdk', '~> 2.0']
     extra_deps << ['ec2-metadata', '~> 0.2']
+    extra_deps << ['slop', '~> 4.2']
     extra_dev_deps << ['hoe', '~> 3.13']
     extra_dev_deps << ['hoe-gemspec', '~> 1.0']
     extra_dev_deps << ['rake', '~> 10.3']

--- a/aws-metadata-export.gemspec
+++ b/aws-metadata-export.gemspec
@@ -1,14 +1,14 @@
 # -*- encoding: utf-8 -*-
-# stub: aws-metadata-export 0.1.0.20150624082252 ruby lib
+# stub: aws-metadata-export 0.2.0.20150804142909 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "aws-metadata-export"
-  s.version = "0.1.0.20150624082252"
+  s.version = "0.2.0.20150804142909"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["James FitzGibbon"]
-  s.date = "2015-06-24"
+  s.date = "2015-08-04"
   s.description = "Exports AWS EC2 Instance metadata and tags to files"
   s.email = ["james@nadt.net"]
   s.executables = ["aws-metadata-export"]
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<aws-sdk>, ["~> 2.0"])
       s.add_runtime_dependency(%q<ec2-metadata>, ["~> 0.2"])
+      s.add_runtime_dependency(%q<slop>, ["~> 4.2"])
       s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_development_dependency(%q<hoe>, ["~> 3.13"])
       s.add_development_dependency(%q<hoe-gemspec>, ["~> 1.0"])
@@ -42,6 +43,7 @@ Gem::Specification.new do |s|
     else
       s.add_dependency(%q<aws-sdk>, ["~> 2.0"])
       s.add_dependency(%q<ec2-metadata>, ["~> 0.2"])
+      s.add_dependency(%q<slop>, ["~> 4.2"])
       s.add_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_dependency(%q<hoe>, ["~> 3.13"])
       s.add_dependency(%q<hoe-gemspec>, ["~> 1.0"])
@@ -59,6 +61,7 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<aws-sdk>, ["~> 2.0"])
     s.add_dependency(%q<ec2-metadata>, ["~> 0.2"])
+    s.add_dependency(%q<slop>, ["~> 4.2"])
     s.add_dependency(%q<rdoc>, ["~> 4.0"])
     s.add_dependency(%q<hoe>, ["~> 3.13"])
     s.add_dependency(%q<hoe-gemspec>, ["~> 1.0"])

--- a/aws-metadata-export.gemspec
+++ b/aws-metadata-export.gemspec
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
-# stub: aws-metadata-export 0.2.0.20150804142909 ruby lib
+# stub: aws-metadata-export 0.2.0.20150804143301 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "aws-metadata-export"
-  s.version = "0.2.0.20150804142909"
+  s.version = "0.2.0.20150804143301"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<aws-sdk>, ["~> 2.0"])
       s.add_runtime_dependency(%q<ec2-metadata>, ["~> 0.2"])
-      s.add_runtime_dependency(%q<slop>, ["~> 4.2"])
+      s.add_runtime_dependency(%q<slop>, ["~> 3.6"])
       s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_development_dependency(%q<hoe>, ["~> 3.13"])
       s.add_development_dependency(%q<hoe-gemspec>, ["~> 1.0"])
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
     else
       s.add_dependency(%q<aws-sdk>, ["~> 2.0"])
       s.add_dependency(%q<ec2-metadata>, ["~> 0.2"])
-      s.add_dependency(%q<slop>, ["~> 4.2"])
+      s.add_dependency(%q<slop>, ["~> 3.6"])
       s.add_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_dependency(%q<hoe>, ["~> 3.13"])
       s.add_dependency(%q<hoe-gemspec>, ["~> 1.0"])
@@ -61,7 +61,7 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<aws-sdk>, ["~> 2.0"])
     s.add_dependency(%q<ec2-metadata>, ["~> 0.2"])
-    s.add_dependency(%q<slop>, ["~> 4.2"])
+    s.add_dependency(%q<slop>, ["~> 3.6"])
     s.add_dependency(%q<rdoc>, ["~> 4.0"])
     s.add_dependency(%q<hoe>, ["~> 3.13"])
     s.add_dependency(%q<hoe-gemspec>, ["~> 1.0"])

--- a/bin/aws-metadata-export
+++ b/bin/aws-metadata-export
@@ -1,5 +1,19 @@
 #!/usr/bin/env ruby
 
 require 'aws-metadata-export'
+require 'slop'
 
-Aws::MetadataExport.new.export
+# parse the command line
+params = { export_tags: true }
+opts = Slop.parse(strict: true, help: true) do
+  banner 'Usage: aws-metadata-export [options]'
+  on 'no-tags', 'Disable export of tags' do
+    params[:export_tags] = false
+  end
+  on 'version', 'print the version' do
+    $stdout.puts Aws::MetadataExport::VERSION
+  end
+end
+
+# export the metadata and tags
+Aws::MetadataExport.new.export(params)

--- a/lib/aws/metadata_export.rb
+++ b/lib/aws/metadata_export.rb
@@ -4,10 +4,10 @@ require 'fileutils'
 
 module Aws
   class MetadataExport
-    def export
+    def export(export_tags: true)
       set_umask
       write_metadata
-      write_tags
+      write_tags if export_tags
     end
 
     private

--- a/lib/aws/metadata_export/version.rb
+++ b/lib/aws/metadata_export/version.rb
@@ -1,5 +1,5 @@
 module Aws
   class MetadataExport
-    VERSION = '0.1.0'
+    VERSION = '0.2.0'
   end
 end

--- a/spec/lib/aws/metadata_export_spec.rb
+++ b/spec/lib/aws/metadata_export_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Aws::MetadataExport do
       .to eq 'us-east-1'
   end
 
-  it 'should export tags' do
+  it 'should export tags by default' do
     @ame.export
     expect(File.exist?('/var/run/aws_metadata_export/tags/foo'))
       .to be true
@@ -52,6 +52,14 @@ RSpec.describe Aws::MetadataExport do
       .to be true
     expect(File.read('/var/run/aws_metadata_export/tags/baz'))
       .to eq 'gzonk'
+  end
+
+  it 'should not export tags when disabled' do
+    @ame.export(export_tags: false)
+    %w(foo baz).each do |tag|
+      expect(File.exist?("/var/run/aws_metadata_export/tags/#{tag}"))
+        .to be false
+    end
   end
 
   it 'should respect the umask env var' do


### PR DESCRIPTION
which lets aws-export-metadata run without an IAM instance role

Version bump to 0.2.0
